### PR TITLE
Add trailing slash to example output_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ usps_mail:
   provider: gmail
   email: 'username@gamil.com'
   password: 'fjkhg347847idsbj'
-  output_dir: '/config/www/USPS'
+  output_dir: '/config/www/USPS/'
 ```
 
 #### Optional config options


### PR DESCRIPTION
Trailing slash needed to avoid /config/www/USPSUSPS.gif .